### PR TITLE
Prepare Weaviate for Railway deployment

### DIFF
--- a/.github/workflows/railway-deploy.yml
+++ b/.github/workflows/railway-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       
       - name: Run tests
         run: |


### PR DESCRIPTION
### What's being changed:

Fixed Go version mismatch in Railway CI/CD pipeline by updating from Go 1.23 to Go 1.24 to align with the project's `go.mod` specification.

**Details:**
- Updated `.github/workflows/railway-deploy.yml` line 19 to use `go-version: '1.24'` instead of `go-version: '1.23'`
- This aligns the CI pipeline with the project's actual Go version requirement specified in `go.mod`
- Verified Docker build still works successfully with Railway configuration (tested locally)

**Context:**
The repository already has comprehensive Railway deployment configuration including:
- Railway-optimized Dockerfile with multi-stage build (188MB final image)
- Complete Railway configuration files (`railway.json`, `railway.toml`)
- Environment variable templates (`.env.railway`)
- Docker Compose setup for Railway (`docker-compose.railway.yml`)
- Comprehensive deployment documentation (`RAILWAY_DEPLOYMENT.md`)

The only issue identified was the Go version mismatch in the CI pipeline that could cause build failures when deploying to Railway.

### Review checklist

- [x] **Go version alignment**: Verify that Go 1.24 in CI matches the project's `go.mod` requirement ✅
- [x] **Docker build verification**: Confirmed Railway Dockerfile builds successfully with Go 1.24 ✅
- [ ] **CI pipeline functionality**: Ensure the workflow still runs correctly with the updated Go version
- [ ] **Railway deployment**: Verify that Railway deployment configuration remains functional
- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A - no documentation changes needed
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary for version alignment fix
- [ ] All new code is covered by tests where it is reasonable. N/A - configuration change only
- [ ] Performance tests have been run or not necessary. Not necessary for version alignment

**Link to Devin session**: https://app.devin.ai/sessions/2b11516e717f49b78bd5468cbff85922  
**Requested by**: Kenneth Logins (@klogins-hash)

**Risk Assessment**: Low risk - single line configuration change to align versions. Main verification needed is that CI pipeline continues to work with Go 1.24.